### PR TITLE
Use Int Array lookup for PolymorphicFormatterResolver

### DIFF
--- a/Akka.Serialization.MessagePack.sln
+++ b/Akka.Serialization.MessagePack.sln
@@ -12,6 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{613896F1-E616-40AB-B7FF-5566285A6595}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
+		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.MessagePack.Benchmarks", "Akka.Serialization.MessagePack.Benchmarks\Akka.Serialization.MessagePack.Benchmarks.csproj", "{A132C115-CCD5-45F0-9D6C-EBFEFF8CB208}"

--- a/Akka.Serialization.MessagePack/Formatters/PolymorphicFormatter.cs
+++ b/Akka.Serialization.MessagePack/Formatters/PolymorphicFormatter.cs
@@ -17,7 +17,11 @@ namespace Akka.Serialization.MessagePack.Resolvers
         public void Serialize(ref MessagePackWriter writer, T value,
             MessagePackSerializerOptions options)
         {
-            if (value.GetType() == typeof(T))
+            if (value == null)
+            {
+                writer.WriteNil();
+            }
+            else if (value.GetType() == typeof(T))
             {
                 _normalFormatter.Serialize(ref writer, value, options);
             }
@@ -51,7 +55,12 @@ namespace Akka.Serialization.MessagePack.Resolvers
                         return (T)TypelessFormatter.Instance.Deserialize(ref reader,
                             options);
                     break;
-                }       
+                }
+                case MessagePackCode.Nil:
+                {
+                    reader.ReadNil();
+                    return default!;
+                }
             }
             
             return _normalFormatter.Deserialize(ref reader, options);

--- a/Akka.Serialization.MessagePack/Formatters/SurrogatedFormatter.cs
+++ b/Akka.Serialization.MessagePack/Formatters/SurrogatedFormatter.cs
@@ -20,9 +20,6 @@ namespace Akka.Serialization.MessagePack.Resolvers
         private static readonly ConcurrentDictionary<string, Type> deserTypeCache =
             new ConcurrentDictionary<string, Type>();
 
-       // internal static readonly ReadOnlyMemory<byte> baseArraySpan = new byte[]
-       //     { (byte)(MessagePackCode.MinFixArray | (byte)3) };
-
         private static readonly Func<string, Type>
             typeLookupFactory = t => Type.GetType(t, true);
 

--- a/Akka.Serialization.MessagePack/Internal/IntIndexedMessagePackFormatterDict.cs
+++ b/Akka.Serialization.MessagePack/Internal/IntIndexedMessagePackFormatterDict.cs
@@ -1,0 +1,80 @@
+using MessagePack.Formatters;
+
+namespace Akka.Serialization.MessagePack.Resolvers;
+
+/// <summary>
+/// A fast, Grow-only structure for holding Created formatters.
+/// Uses Int indexes per-type to avoid ConcurrentDictionary bucket costs,
+/// And avoids volatile/lock entirely on the happy path.
+/// </summary>
+/// <remarks>
+/// This can be (in some cases) less space efficient than a normal dictionary,
+/// However, for most internal uses, the cost is going to be fairly bounded,
+/// and <see cref="PolymorphicFormatterResolver"/>'s behavior results in
+/// <see cref="PolymorphicFormatterResolver.GetFormatter{T}"/> being a hot path,
+/// So in general the alloc cost is worth it. 
+/// </remarks>
+internal sealed class IntIndexedMessagePackFormatterDict
+{
+    private IMessagePackFormatter?[] _formatters;
+    private readonly object _lockObj = new();
+    public IntIndexedMessagePackFormatterDict(int initialSize)
+    {
+        _formatters = new IMessagePackFormatter[256];
+    }
+        
+    public bool TryGet(int i, out IMessagePackFormatter? formatter)
+    {
+        //No Fence here.
+        //If the read happened to be dirty, that's fine.
+        //Should it happen, it just means we trust `TryAdd`
+        //which does a full fence and then checks state.
+        //Shouldn't happen much and only on startup...
+        var f = _formatters;
+        if (i > f.Length)
+        {
+            formatter = default;
+            return false;
+        }
+        else
+        {
+            formatter = f[i];
+            return formatter != default;
+        }
+            
+    }
+
+    public IMessagePackFormatter TryAdd(int i, IMessagePackFormatter formatter)
+    {
+        //This may result in locks earlier on in an app,
+        //However this will not impact types that can already be deserialized,
+        //and since we are always in a full fence here can ensure we don't
+        //accidentally fail to share an instance.
+        
+        lock (_lockObj)
+        {
+            //We care about two things in the lock.
+            //First, if we need a resize, we do the resize,
+            //       and just copy the instance over because we have lock.
+            //Otherwise, we check whether we are there
+            //           (if a competitor added it on resize, we see via fence)
+            //           and if not, add ours.
+            if (_formatters.Length <= i)
+            {
+                //Resize. Copy everything over first,
+                //And then add our version before setting the new version.
+                var newF =
+                    new IMessagePackFormatter?[_formatters.Length * 2];
+                _formatters.CopyTo(newF.AsSpan());
+                newF[i] = formatter;
+                _formatters = newF;
+            }
+            else if (_formatters[i] == null)
+            {
+                _formatters[i] = formatter;
+            }
+        }
+
+        return _formatters[i]!;
+    }
+}

--- a/Akka.Serialization.MessagePack/Internal/SurrogateTypeDictCtr.cs
+++ b/Akka.Serialization.MessagePack/Internal/SurrogateTypeDictCtr.cs
@@ -1,0 +1,11 @@
+namespace Akka.Serialization.MessagePack.Resolvers;
+
+internal static class SurrogateTypeDictCtr
+{
+    private static int _typeCtr;
+
+    internal static int doNotCallExternally()
+    {
+        return Interlocked.Increment(ref _typeCtr);
+    }
+}

--- a/Akka.Serialization.MessagePack/Internal/SurrogatedTypeDict.cs
+++ b/Akka.Serialization.MessagePack/Internal/SurrogatedTypeDict.cs
@@ -1,0 +1,12 @@
+namespace Akka.Serialization.MessagePack.Resolvers;
+
+/// <summary>
+/// Used to provide indexes into a fast array lookup for resolvers.
+/// </summary>
+internal static class SurrogatedTypeDict<T>
+{
+    //WARNING, Read Notes!
+    //It's ok that we return -1 here,
+    //Since it's never going to actually be used on a path
+    public static readonly int TypeVal = SurrogateResolvable<T>.IsSurrogated ? SurrogateTypeDictCtr.doNotCallExternally() : -1;
+}

--- a/Akka.Serialization.MessagePack/Internal/TypeDict.cs
+++ b/Akka.Serialization.MessagePack/Internal/TypeDict.cs
@@ -1,0 +1,9 @@
+namespace Akka.Serialization.MessagePack.Resolvers;
+
+/// <summary>
+/// Used to provide indexes into a fast array lookup for resolvers.
+/// </summary>
+internal static class TypeDict<T>
+{
+    public static readonly int TypeVal = TypeDictCtr.doNotCallExternally();
+}

--- a/Akka.Serialization.MessagePack/Internal/TypeDictCtr.cs
+++ b/Akka.Serialization.MessagePack/Internal/TypeDictCtr.cs
@@ -1,0 +1,14 @@
+namespace Akka.Serialization.MessagePack.Resolvers;
+
+/// <summary>
+/// Used as a Counter for <see cref="TypeDict{T}"/> calls.
+/// </summary>
+internal static class TypeDictCtr
+{
+    private static int _typeCtr;
+
+    internal static int doNotCallExternally()
+    {
+        return Interlocked.Increment(ref _typeCtr);
+    }
+}

--- a/Akka.Serialization.MessagePack/MsgPackSerializer.cs
+++ b/Akka.Serialization.MessagePack/MsgPackSerializer.cs
@@ -24,11 +24,12 @@ namespace Akka.Serialization.MessagePack
     {
         private readonly MsgPackSerializerSettings _settings;
         private readonly IFormatterResolver _resolver;
-        public readonly MessagePackSerializerOptions _serializerOptions;
+        public readonly MessagePackSerializerOptions SerializerOptions;
         private readonly IFormatterResolver _polymorphicResolver;
 
         public MsgPackSerializer(ExtendedActorSystem system) : this(system, MsgPackSerializerSettings.Default)
         {
+
         }
 
         public MsgPackSerializer(ExtendedActorSystem system, Config config) 
@@ -121,7 +122,9 @@ namespace Akka.Serialization.MessagePack
                         LoadFormatterResolverByType(t, system))
                     .Concat(new[]
                     {
+#if SERIALIZATION
                         SerializableResolver.Instance,
+#endif
                         ImmutableCollectionResolver.Instance,
                         settings.UseOldFormatterCompatibility
                             ? (IFormatterResolver)new
@@ -156,20 +159,20 @@ namespace Akka.Serialization.MessagePack
             //We handle type filtering via our own options set.
             //By doing so, the existing Typeless API will hook in,
             //i.e. we don't have to write our own Typeless Filter.
-            _serializerOptions = new MessagePackTypeFilteringOptions(opts);
+            SerializerOptions = new MessagePackTypeFilteringOptions(opts);
 
         }
 
         public override byte[] ToBinary(object obj)
         {
             {
-                return MessagePackSerializer.Serialize(obj.GetType(), obj,_serializerOptions);
+                return MessagePackSerializer.Serialize(obj.GetType(), obj,SerializerOptions);
             }
         }
 
         public override object FromBinary(byte[] bytes, Type type)
         {
-            return MessagePackSerializer.Deserialize(type, bytes,_serializerOptions);
+            return MessagePackSerializer.Deserialize(type, bytes,SerializerOptions);
         }
 
         public override int Identifier => 151;

--- a/Akka.Serialization.MessagePack/MsgPackSerializer.cs
+++ b/Akka.Serialization.MessagePack/MsgPackSerializer.cs
@@ -122,9 +122,7 @@ namespace Akka.Serialization.MessagePack
                         LoadFormatterResolverByType(t, system))
                     .Concat(new[]
                     {
-#if SERIALIZATION
                         SerializableResolver.Instance,
-#endif
                         ImmutableCollectionResolver.Instance,
                         settings.UseOldFormatterCompatibility
                             ? (IFormatterResolver)new

--- a/Akka.Serialization.MessagePack/Resolvers/BackwardsCompatibleSurrogatedFormatterResolver.cs
+++ b/Akka.Serialization.MessagePack/Resolvers/BackwardsCompatibleSurrogatedFormatterResolver.cs
@@ -1,33 +1,26 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="AkkaResolver.cs" company="Akka.NET Project">
-//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Serialization.MessagePack>
-// </copyright>
-//-----------------------------------------------------------------------
-
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Akka.Actor;
-using Akka.Util.Internal;
 using MessagePack;
 using MessagePack.Formatters;
 
 namespace Akka.Serialization.MessagePack.Resolvers
 {
-    public class SurrogatedFormatterResolver : IFormatterResolver, IDoNotUsePolymorphicFormatter
+    public class BackwardsCompatibleSurrogatedFormatterResolver : IFormatterResolver, IDoNotUsePolymorphicFormatter
     {
+
         private readonly ConcurrentDictionary<Type, IMessagePackFormatter>
             _formatterCache =
                 new ConcurrentDictionary<Type, IMessagePackFormatter>();
 
         private readonly Func<Type, IMessagePackFormatter> _formatterCreateFunc;
-        public SurrogatedFormatterResolver(ExtendedActorSystem system)
+        public BackwardsCompatibleSurrogatedFormatterResolver(ExtendedActorSystem system)
         {
             //Cast in the func since we'll have to cache anyway.
             //The alternative is making a 'nullable' func in another static class,
             //But that may result in too much garbage for other types.
             _formatterCreateFunc = t =>
-                (IMessagePackFormatter)typeof(SurrogatedFormatter<>)
+                (IMessagePackFormatter)typeof(BackwardsCompatibleSurrogatedFormatter<>)
                     .MakeGenericType(t)
                     .GetConstructor(new[] { typeof(ActorSystem) })
                     .Invoke(new[] { system });

--- a/Akka.Serialization.MessagePack/Resolvers/PolymorphicFormatterResolver.cs
+++ b/Akka.Serialization.MessagePack/Resolvers/PolymorphicFormatterResolver.cs
@@ -2,18 +2,28 @@ using System;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Akka.Util;
+using CommunityToolkit.HighPerformance;
 using MessagePack;
 using MessagePack.Formatters;
 
 namespace Akka.Serialization.MessagePack.Resolvers
 {
+    /// <summary>
+    /// A 'Wrapping' resolver that,
+    /// When provided as the 'base' resolver for MessagePack,
+    /// Applies Polymorphic formatting rules to serialization,
+    /// When the instanced type does not match runtime type.
+    /// If you do not want this behavior, you may explicitly opt out
+    /// Via ISurrogate, or have your in-chain Resolver provide a formatter
+    /// That has the <see cref="IDoNotUsePolymorphicFormatter"/>
+    /// Interface inherited
     public class PolymorphicFormatterResolver : IFormatterResolver
     {
         private readonly IFormatterResolver _normalResolver;
 
-        private readonly ConcurrentDictionary<Type, IMessagePackFormatter>
-            _formatterDict =
-                new ConcurrentDictionary<Type, IMessagePackFormatter>();
+        private readonly IntIndexedMessagePackFormatterDict _formatterDict =
+            new IntIndexedMessagePackFormatterDict(256);
+        
         public PolymorphicFormatterResolver(IFormatterResolver normalResolver)
         {
             _normalResolver = normalResolver;
@@ -21,9 +31,13 @@ namespace Akka.Serialization.MessagePack.Resolvers
         
         public IMessagePackFormatter<T> GetFormatter<T>()
         {
-            if (_formatterDict.TryGetValue(typeof(T), out var formatter))
+            if (_formatterDict.TryGet(TypeDict<T>.TypeVal,out var formatter))
             {
-                return (IMessagePackFormatter<T>)formatter;
+                //IMPORTANT!
+                // This assumes that MakeValue<T> is doing a proper
+                // sanity check on the formatter
+                // produced by underlying resolver.
+                return Unsafe.As<IMessagePackFormatter<T>>(formatter);
             }
             else
             {
@@ -34,10 +48,26 @@ namespace Akka.Serialization.MessagePack.Resolvers
         [MethodImpl(MethodImplOptions.NoInlining)]
         private IMessagePackFormatter<T> MakeValue<T>()
         {
-            //We don't have GetOrAdd in NetStandard2.0
-            //So instead we suffer and do our own double-checks
-            IMessagePackFormatter<T> formatterToUse = _normalResolver.GetFormatter<T>();
-            if ((_normalResolver is IDoNotUsePolymorphicFormatter) == false &&
+            // IMPORTANT!!!
+            // For type safety make sure to read comments!!!
+            // If you break below assumptions,
+            // GetFormatter may require refactor!
+            //
+            // The explicit-casting here,
+            // is to ensure we do a type check on returned value.
+            // This helps guarantee our Unsafe calls are safe in context.
+            // Since this is not at all the hot path,
+            // easy cost to justify for retaining type safety.
+            // 
+            // Minor Note:
+            // It's possible that we wastefully alloc here,
+            // However our 'wrapped' formatter should be caching,
+            // and the Polymorphic formatter itself is just a ref,
+            // so it's a cheap temporary cost to pay.
+            IMessagePackFormatter<T> formatterToUse =
+                (IMessagePackFormatter<T>)(object)_normalResolver
+                    .GetFormatter<T>();
+            if ((formatterToUse is IDoNotUsePolymorphicFormatter) == false &&
                 typeof(T).IsClass)
             {
                 if ((typeof(T).IsAbstract || !typeof(T).IsSealed) &&
@@ -47,9 +77,8 @@ namespace Akka.Serialization.MessagePack.Resolvers
                         new PolymorphicFormatter<T>(formatterToUse);
                 }
             }
-            
-            _formatterDict.TryAdd(typeof(T),formatterToUse);
-            return (IMessagePackFormatter<T>)_formatterDict[typeof(T)];
+
+            return (IMessagePackFormatter<T>)_formatterDict.TryAdd(TypeDict<T>.TypeVal,formatterToUse);
         }
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.0 January 29th 2024 ####
+
+*Placeholder for nightlies*
+
 #### 1.1.0 January 9th 2024 ####
 
 *Placeholder*


### PR DESCRIPTION
## Changes

Use optimistic lookup Int Array instead of Concurrentdictionary for `PolymorphicFormatterResolver`.

No wire or format changes, internal only.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Benchmarks 

I don't have numbers handy but this results in a >5% improvement in serialization benchmarks (due to lack of volatile reads or barriers on happy path and unsafe magic). Can produce receipts if needed. <3