### PR TITLE
Update RELEASE_NOTES.md for 1.5.15-beta1 release

### DIFF
--- a/Akka.Serialization.MessagePack.sln
+++ b/Akka.Serialization.MessagePack.sln
@@ -13,6 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
+		build.ps1 = build.ps1
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.MessagePack.Benchmarks", "Akka.Serialization.MessagePack.Benchmarks\Akka.Serialization.MessagePack.Benchmarks.csproj", "{A132C115-CCD5-45F0-9D6C-EBFEFF8CB208}"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,3 @@
-#### 1.5.0 January 29th 2024 ####
+#### 1.5.15-beta1 January 29th 2024 ####
 
-*Placeholder for nightlies*
-
-#### 1.1.0 January 9th 2024 ####
-
-*Placeholder*
+* First Beta release for Akka.Serialization.MessagePack

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
 #### 1.5.15-beta1 February 15 2024 ####
 
-* First Beta release for Akka.Serialization.MessagePack
+Akka.Serialization.MessagePack Beta release for Akka.NET v1.5
+
+* [Upgrade Akka.Net to 1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
+* [Better polymorphism handling](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/27)
+* [Use int array lookup for polymorphic resolver](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/42)
+* [Handle edge case for dictionary lookup](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/44)
+* [Fix off-by-one waste in IntIndexedDict](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/45)
+* [Bump MessagePack to 2.4](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/24)
+* [Bump CommunityToolkit.HighPerformance to 8.2.2](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/36)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-#### 1.5.15-beta1 January 29th 2024 ####
+#### 1.5.15-beta1 February 15 2024 ####
 
 * First Beta release for Akka.Serialization.MessagePack


### PR DESCRIPTION
## 1.5.15-beta1 February 15 2024

Akka.Serialization.MessagePack Beta release for Akka.NET v1.5

* [Upgrade Akka.Net to 1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
* [Better polymorphism handling](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/27)
* [Use int array lookup for polymorphic resolver](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/42)
* [Handle edge case for dictionary lookup](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/44)
* [Fix off-by-one waste in IntIndexedDict](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/45)
* [Bump MessagePack to 2.4](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/24)
* [Bump CommunityToolkit.HighPerformance to 8.2.2](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/36)
