### PR TITLE
Update RELEASE_NOTES.md for 1.5.16-beta1 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
-#### 1.5.15-beta1 February 15 2024 ####
+#### 1.5.16-beta1 February 14 2024 ####
 
 Akka.Serialization.MessagePack Beta release for Akka.NET v1.5
 
-* [Upgrade Akka.Net to 1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
+* [Upgrade Akka.Net to 1.5.16](https://github.com/akkadotnet/akka.net/releases/tag/1.5.16)
 * [Better polymorphism handling](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/27)
 * [Use int array lookup for polymorphic resolver](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/42)
 * [Handle edge case for dictionary lookup](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/44)


### PR DESCRIPTION
## 1.5.16-beta1 February 14 2024

Akka.Serialization.MessagePack Beta release for Akka.NET v1.5

* [Upgrade Akka.Net to 1.5.16](https://github.com/akkadotnet/akka.net/releases/tag/1.5.16)
* [Better polymorphism handling](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/27)
* [Use int array lookup for polymorphic resolver](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/42)
* [Handle edge case for dictionary lookup](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/44)
* [Fix off-by-one waste in IntIndexedDict](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/45)
* [Bump MessagePack to 2.4](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/24)
* [Bump CommunityToolkit.HighPerformance to 8.2.2](https://github.com/akkadotnet/Akka.Serialization.MessagePack/pull/36)