### PR TITLE
Add SerializerId override support for backward compatibility

### DIFF
--- a/Akka.Serialization.MessagePack.Tests/MsgPackSerializerIdTests.cs
+++ b/Akka.Serialization.MessagePack.Tests/MsgPackSerializerIdTests.cs
@@ -1,0 +1,41 @@
+﻿// -----------------------------------------------------------------------
+//   <copyright file="MsgPackSerializerOverrideTests.cs" company="Petabridge, LLC">
+//     Copyright (C) 2015-2024 .NET Petabridge, LLC
+//   </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Serialization.Testkit.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Serialization.MessagePack.Tests;
+
+public class MsgPackSerializerIdTests: TestKit.Xunit2.TestKit
+{
+    public MsgPackSerializerIdTests() : base(ConfigFactory.GetConfig(typeof(MsgPackSerializer), true))
+    {
+    }
+
+    [Fact(DisplayName = "Must be able to override serializer id from HOCON settings")]
+    public void OverridenIdTest()
+    {
+        var serializer = Sys.Serialization.FindSerializerForType(typeof(object));
+        serializer.Should().BeOfType<MsgPackSerializer>();
+        serializer.Identifier.Should().Be(ConfigFactory.SerializerIdOverride);
+    }
+}
+
+public class MsgPackDefaultSerializerIdTests: TestKit.Xunit2.TestKit
+{
+    public MsgPackDefaultSerializerIdTests() : base(ConfigFactory.GetConfig(typeof(MsgPackSerializer)))
+    {
+    }
+
+    [Fact(DisplayName = "Default serializer ID must be the default value")]
+    public void OverridenIdTest()
+    {
+        var serializer = Sys.Serialization.FindSerializerForType(typeof(object));
+        serializer.Should().BeOfType<MsgPackSerializer>();
+        serializer.Identifier.Should().Be(MsgPackSerializer.DefaultSerializerId);
+    }
+}

--- a/Akka.Serialization.MessagePack/MsgPackSerializer.cs
+++ b/Akka.Serialization.MessagePack/MsgPackSerializer.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Serialization.MessagePack.Resolvers;
-using Akka.Util;
 using MessagePack;
 using MessagePack.Formatters;
 using MessagePack.ImmutableCollection;

--- a/Akka.Serialization.MessagePack/Sample.hocon
+++ b/Akka.Serialization.MessagePack/Sample.hocon
@@ -1,35 +1,42 @@
 
 akka.actor {
-    serializers.messagepack = "Akka.Serialization.MessagePack.MsgPackSerializer, Akka.Serialization.MessagePack"
-    serialization-bindings {
-        "System.Object" = messagepack
-    }
+  serializers{
+    messagepack = "Akka.Serialization.MessagePack.MsgPackSerializer, Akka.Serialization.MessagePack"
+  }
+  serialization-bindings {
+    "System.Object" = messagepack
+  }
+  serialization-identifiers {
+    # This setting is only needed if you need to override the serializer id of the serializer.
+    #
+    # The value before v1.5.16-beta1 was 150
+    # The default value at v1.5.16-beta1 and above is 151
+    "Akka.Serialization.MessagePack.MsgPackSerializer, Akka.Serialization.MessagePack" = 151
+  }
   serialization-settings {
-      messagepack {
-        
-        # Use "Lz4BlockArray" or "Lz4Block" to enable.
-        # "Lz4BlockArray" is reccomended by MessagePack author.
-        # Note that all sides must have this set!
-        enable-lz4-compression = "none"
-        
-        # If False, Assembly version mismatches on typeless types may throw!
-        allow-assembly-version-mismatch = true
-        
-        # If True, Assembly version is included in typeless serialized data. 
-        omit-assembly-version = true
-        
-        # A set of converters with FQCN (Including assembly) to use,
-        # before falling back to the TypelessFormatter.
-        # Note that Other converters like Akka surrogates are registered -before-
-        # these. If you need to party on those types, use 'converters-override' instead 
-        converters = []
-        
-        # A set of 'Override' converters with FQCN (including assmebly) to use,
-        # BEFORE All other converters.
-        # This may break Akka Serialization if you are not careful!
-        converters-override = [] 
-        
-      }
+    messagepack {
+      
+      # Use "Lz4BlockArray" or "Lz4Block" to enable.
+      # "Lz4BlockArray" is reccomended by MessagePack author.
+      # Note that all sides must have this set!
+      enable-lz4-compression = "none"
+      
+      # If False, Assembly version mismatches on typeless types may throw!
+      allow-assembly-version-mismatch = true
+      
+      # If True, Assembly version is included in typeless serialized data. 
+      omit-assembly-version = true
+      
+      # A set of converters with FQCN (Including assembly) to use,
+      # before falling back to the TypelessFormatter.
+      # Note that Other converters like Akka surrogates are registered -before-
+      # these. If you need to party on those types, use 'converters-override' instead 
+      converters = []
+      
+      # A set of 'Override' converters with FQCN (including assmebly) to use,
+      # BEFORE All other converters.
+      # This may break Akka Serialization if you are not careful!
+      converters-override = [] 
     }
   }
 }

--- a/Akka.Serialization.Testkit/Util/ConfigFactory.cs
+++ b/Akka.Serialization.Testkit/Util/ConfigFactory.cs
@@ -8,22 +8,25 @@ using System;
 
 namespace Akka.Serialization.Testkit.Util
 {
-    public class ConfigFactory
+    public static class ConfigFactory
     {
-        public static string GetConfig(Type serializerType)
+        public const int SerializerIdOverride = 150;
+        
+        public static string GetConfig(Type serializerType, bool overrideSerializerId = false)
         {
-            return @"
-                akka.actor {
-                    serializers.msgpack = """ + serializerType.AssemblyQualifiedName + @"""
-                    serialization-bindings {
+            return $@"
+                akka.actor {{
+                    serializers.msgpack = ""{serializerType.AssemblyQualifiedName}""
+                    serialization-bindings {{
                       ""System.Object"" = msgpack
-                    }
-	                serialization-settings {
-		                msgpack {
+                    }}
+	                serialization-settings {{
+		                msgpack {{
 			                enable-lz4-compression = false
-		                }
-	                }
-                }";
+		                }}
+	                }}
+{(overrideSerializerId ? $"serialization-identifiers {{ \"{serializerType.AssemblyQualifiedName}\" : {SerializerIdOverride} }}" : "")}
+                }}";
         }
     }
 }


### PR DESCRIPTION
## Changes

Add a way to override the serializer id using the HOCON configuration

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] I have added website documentation for this feature.