### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2024 Akka.NET Project</Copyright>
     <NoWarn>$(NoWarn);CS1591;NU1701;CA1707;</NoWarn>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
     <Authors>Akka.NET Team</Authors>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Serialization.MessagePack</PackageProjectUrl>
-    <PackageReleaseNotes>* [Resolved `AK2001`: `if` statements not cleanly managed by Code Fix](https://github.com/akkadotnet/akka.analyzers/pull/46)</PackageReleaseNotes>
+    <PackageReleaseNotes>* [Upgrade Akka.Net to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
     <PackageTags>akka;actors;actor model;Akka;concurrency;messagepack;serializer;serialization</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -15,13 +15,11 @@
       MsgPack serialization support for Akka.NET.      
     </Description>
   </PropertyGroup>
-
   <PropertyGroup Label="Build">
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\logo.png" Pack="true" Visible="false" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" Visible="false" PackagePath="\" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,9 @@
     </PropertyGroup>
     <!-- Akka.NET Package Versions -->
     <ItemGroup>
-        <PackageVersion Include="Akka" Version="1.5.33" />
-        <PackageVersion Include="Akka.Serialization.Hyperion" Version="1.5.33" />
-        <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.31" />
+        <PackageVersion Include="Akka" Version="1.5.59" />
+        <PackageVersion Include="Akka.Serialization.Hyperion" Version="1.5.59" />
+        <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.59" />
     </ItemGroup>
 
     <!-- MsgPack Versions -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.59 January 26th 2025 ####
+
+* [Upgrade Akka.Net to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+
 #### 1.5.31 November 26th 2024 ####
 
 This is the RTM release of Akka.Serialization.MessagePack


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)