### PR TITLE
Bump AkkaVersion to 1.5.60

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,9 @@
     </PropertyGroup>
     <!-- Akka.NET Package Versions -->
     <ItemGroup>
-        <PackageVersion Include="Akka" Version="1.5.59" />
-        <PackageVersion Include="Akka.Serialization.Hyperion" Version="1.5.59" />
-        <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.59" />
+        <PackageVersion Include="Akka" Version="1.5.60" />
+        <PackageVersion Include="Akka.Serialization.Hyperion" Version="1.5.60" />
+        <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.60" />
     </ItemGroup>
 
     <!-- MsgPack Versions -->


### PR DESCRIPTION
Updates Akka.NET dependencies to version 1.5.60.

## Changes
- Updated `Akka` from 1.5.59 to 1.5.60
- Updated `Akka.Serialization.Hyperion` from 1.5.59 to 1.5.60
- Updated `Akka.TestKit.Xunit2` from 1.5.59 to 1.5.60

## Test Results
All 66 tests passed successfully.